### PR TITLE
Changes for aggregation pipeline lookup

### DIFF
--- a/db/aggregate.go
+++ b/db/aggregate.go
@@ -26,6 +26,7 @@ func Aggregate[Result any](mongikClient *mongik.Mongik, db string, collectionNam
 			if strings.Contains(tag, "from:") {
 				res := strings.Split(tag, "from:")
 				lookupCollection = res[1]
+				break
 			}
 		}
 	}
@@ -75,6 +76,7 @@ func AggregateOne[Result any](mongikClient *mongik.Mongik, db string, collection
 			if strings.Contains(tag, "from:") {
 				res := strings.Split(tag, "from:")
 				lookupCollection = res[1]
+				break
 			}
 		}
 	}

--- a/db/cache.go
+++ b/db/cache.go
@@ -13,7 +13,7 @@ func getDBClusterFromKey(key string) string {
 	return strings.Split(key, " | ")[0]
 }
 
-func DBCacheSet(cacheClient *bigcache.BigCache, key string, value []byte) error {
+func DBCacheSet(cacheClient *bigcache.BigCache, key string, value []byte, lookupCollection ...string) error {
 	// Get the list of keys
 	var keyStore map[string][]string
 	keyStoreBytes, _ := cacheClient.Get(constants.KEY_STORE)
@@ -25,6 +25,9 @@ func DBCacheSet(cacheClient *bigcache.BigCache, key string, value []byte) error 
 
 	// Add it to the cluster set
 	keyStore[clusterName] = append(keyStore[clusterName], key)
+	if lookupCollection != nil {
+		keyStore[lookupCollection[0]] = append(keyStore[lookupCollection[0]], key)
+	}
 
 	// Set the key store
 	keyStoreBytes, _ = json.Marshal(keyStore)

--- a/db/cache.go
+++ b/db/cache.go
@@ -13,7 +13,7 @@ func getDBClusterFromKey(key string) string {
 	return strings.Split(key, " | ")[0]
 }
 
-func DBCacheSet(cacheClient *bigcache.BigCache, key string, value []byte, lookupCollection ...string) error {
+func DBCacheSet(cacheClient *bigcache.BigCache, key string, value []byte, lookupCollections ...string) error {
 	// Get the list of keys
 	var keyStore map[string][]string
 	keyStoreBytes, _ := cacheClient.Get(constants.KEY_STORE)
@@ -25,8 +25,10 @@ func DBCacheSet(cacheClient *bigcache.BigCache, key string, value []byte, lookup
 
 	// Add it to the cluster set
 	keyStore[clusterName] = append(keyStore[clusterName], key)
-	if lookupCollection != nil {
-		keyStore[lookupCollection[0]] = append(keyStore[lookupCollection[0]], key)
+	if lookupCollections != nil {
+		for _, collection := range lookupCollections {
+			keyStore[collection] = append(keyStore[collection], key)
+		}
 	}
 
 	// Set the key store

--- a/db/find.go
+++ b/db/find.go
@@ -71,18 +71,3 @@ func Find[Result any](mongikClient *mongik.Mongik, db string, collectionName str
 
 	return result, nil
 }
-
-func FindOneAndUpdate[Result any](mongikClient *mongik.Mongik, db string, collectionName string, query bson.M, update bson.M, opts ...*options.FindOneAndUpdateOptions) Result {
-	var result Result
-	var resultInterface map[string]interface{}
-
-	fmt.Println("Querying the DB")
-	mongikClient.MongoClient.Database(db).Collection(collectionName).FindOneAndUpdate(context.Background(), query, update, opts...).Decode(&resultInterface)
-
-	resultBody, _ := json.Marshal(resultInterface)
-	json.Unmarshal(resultBody, &result)
-
-	DBCacheReset(mongikClient.CacheClient, collectionName)
-
-	return result
-}

--- a/db/update.go
+++ b/db/update.go
@@ -2,6 +2,7 @@ package mongik
 
 import (
 	"context"
+	"fmt"
 
 	mongik "github.com/FrosTiK-SD/mongik/models"
 	"go.mongodb.org/mongo-driver/bson"
@@ -23,4 +24,19 @@ func UpdateMany[Doc any](mongikClient *mongik.Mongik, db string, collectionName 
 
 	DBCacheReset(mongikClient.CacheClient, collectionName)
 	return result, err
+}
+
+func FindOneAndUpdate[Result any](mongikClient *mongik.Mongik, db string, collectionName string, query bson.M, update bson.M, opts ...*options.FindOneAndUpdateOptions) Result {
+	var result Result
+	var resultInterface map[string]interface{}
+
+	fmt.Println("Querying the DB")
+	mongikClient.MongoClient.Database(db).Collection(collectionName).FindOneAndUpdate(context.Background(), query, update, opts...).Decode(&resultInterface)
+
+	resultBody, _ := json.Marshal(resultInterface)
+	json.Unmarshal(resultBody, &result)
+
+	DBCacheReset(mongikClient.CacheClient, collectionName)
+
+	return result
 }

--- a/db/utils.go
+++ b/db/utils.go
@@ -3,6 +3,8 @@ package mongik
 import (
 	"fmt"
 	"reflect"
+
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 func getKey[Option any](collectionName string, operation string, query interface{}, option []*Option) string {
@@ -26,4 +28,21 @@ func iterateStructFields(input interface{}) string {
 		}
 	}
 	return structKey + " }"
+}
+
+func getLookupCollections(pipeline []bson.M) []string {
+	var res []string
+	for _, val := range pipeline {
+		stage, exists := val["$lookup"]
+		if exists == true {
+			stageInterface := stage.(bson.M)
+			if stageInterface != nil {
+				collectionName, exists := stageInterface["from"]
+				if exists == true {
+					res = append(res, collectionName.(string))
+				}
+			}
+		}
+	}
+	return res
 }

--- a/db/utils.go
+++ b/db/utils.go
@@ -3,8 +3,6 @@ package mongik
 import (
 	"fmt"
 	"reflect"
-
-	"github.com/FrosTiK-SD/mongik/constants"
 )
 
 func getKey[Option any](collectionName string, operation string, query interface{}, option []*Option) string {
@@ -12,7 +10,7 @@ func getKey[Option any](collectionName string, operation string, query interface
 	for _, opt := range option {
 		optionKey += iterateStructFields(*opt)
 	}
-	return fmt.Sprintf("%s | %s | %v | %v", collectionName, constants.DB_FINDONE, query, optionKey)
+	return fmt.Sprintf("%s | %s | %v | %v", collectionName, operation, query, optionKey)
 }
 
 func iterateStructFields(input interface{}) string {


### PR DESCRIPTION
Parses lookup collection name from pipeline interface and then adds the query key to the keystore of the lookup collection as well as query collection. This ensures aggregation query is invalidated when either of the collections have any insert/update/delete operations